### PR TITLE
Fix React Warning About Missing Keys

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -69,16 +69,16 @@ export default function Home() {
           </tr>
         </thead>
         <tbody>
-          {filteredAdvocates.map((advocate) => {
+          {filteredAdvocates.map((advocate, index) => {
             return (
-              <tr>
+              <tr key ={index}>
                 <td>{advocate.firstName}</td>
                 <td>{advocate.lastName}</td>
                 <td>{advocate.city}</td>
                 <td>{advocate.degree}</td>
                 <td>
-                  {advocate.specialties.map((s) => (
-                    <div>{s}</div>
+                  {advocate.specialties.map((s, idx) => (
+                    <div key={idx}>{s}</div>
                   ))}
                 </td>
                 <td>{advocate.yearsOfExperience}</td>


### PR DESCRIPTION
## Description: Bug fix
Fix React key props error about missing keys

## Fix
Fixed React warning about missing keys using map operations. This was caught by the error popup and inspecting the Chrome console.