### PR TITLE
Ease case-sensitive search functionality restrictions

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,15 +22,15 @@ export default function Home() {
 
     document.getElementById("search-term").innerHTML = searchTerm;
 
-    console.log("filtering advocates...");
     const filteredAdvocates = advocates.filter((advocate: Advocate) => {
+      const lowerSearchTerm = searchTerm.toLowerCase();
       return (
-        advocate.firstName.includes(searchTerm) ||
-        advocate.lastName.includes(searchTerm) ||
-        advocate.city.includes(searchTerm) ||
-        advocate.degree.includes(searchTerm) ||
-        advocate.specialties.includes(searchTerm) ||
-        advocate.yearsOfExperience.includes(searchTerm)
+        advocate.firstName.toLowerCase().includes(lowerSearchTerm) ||
+        advocate.lastName.toLowerCase().includes(lowerSearchTerm) ||
+        advocate.city.toLowerCase().includes(lowerSearchTerm) ||
+        advocate.degree.toLowerCase().includes(lowerSearchTerm) ||
+        advocate.specialties.some(specialty => specialty.toLowerCase().includes(lowerSearchTerm)) ||
+        advocate.yearsOfExperience.toString().includes(searchTerm)
       );
     });
 


### PR DESCRIPTION
## Description

Search functionality is currently case sensitive and too restrictive. 
1. If a user types in "john", the advocate "John" does not appear. 
2. If a user types in "ptsd", there is a runtime error.
3. If a user types in "1" for years of experience, the app crashes.

## Fix
1. Change all searches to lower case on client and backend response to properly match strings.
2. Check specialities array to filter for `some` versus `includes`.
3. Change number input to strings to compare for years of experience. 

